### PR TITLE
Separate approve and cancel order

### DIFF
--- a/app/Application/UseCases/ApproveTravelOrderUseCase.php
+++ b/app/Application/UseCases/ApproveTravelOrderUseCase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Application\UseCases;
+
+use App\Domain\Entities\TravelOrder;
+use App\Domain\Enums\TravelOrderStatus;
+use App\Domain\Repositories\TravelOrderRepositoryInterface;
+use Exception;
+use Tymon\JWTAuth\Facades\JWTAuth;
+use App\Application\UseCases\Traits\RulesTravelOrderStatus;
+
+class ApproveTravelOrderUseCase
+{
+    use RulesTravelOrderStatus;
+
+    private $repository;
+
+    public function __construct(TravelOrderRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function execute(int $id): ?TravelOrder
+    {
+        $order = $this->repository->findById($id);
+        
+        if (!$order) {
+            throw new Exception("Pedido não encontrado.");
+        }
+
+        $user = JWTAuth::parseToken()->authenticate();
+        $currentUserId = $user?->id;
+
+        $this->ruleSomeUserCannotChangeOwnRequest($order, $currentUserId);
+        $this->ruleOnlyPendingOrdersCanBeUpdated($order);
+
+        $order->setStatus(TravelOrderStatus::APPROVED);
+        return $this->repository->update($order);
+    }
+}

--- a/app/Application/UseCases/CancelTravelOrderUseCase.php
+++ b/app/Application/UseCases/CancelTravelOrderUseCase.php
@@ -7,9 +7,12 @@ use App\Domain\Enums\TravelOrderStatus;
 use App\Domain\Repositories\TravelOrderRepositoryInterface;
 use Exception;
 use Tymon\JWTAuth\Facades\JWTAuth;
+use App\Application\UseCases\Traits\RulesTravelOrderStatus;
 
-class UpdateStatusTravelOrderUseCase
+class CancelTravelOrderUseCase
 {
+    use RulesTravelOrderStatus;
+
     private $repository;
 
     public function __construct(TravelOrderRepositoryInterface $repository)
@@ -17,7 +20,7 @@ class UpdateStatusTravelOrderUseCase
         $this->repository = $repository;
     }
 
-    public function execute(int $id, TravelOrderStatus $status): ?TravelOrder
+    public function execute(int $id): ?TravelOrder
     {
         $order = $this->repository->findById($id);
         
@@ -31,21 +34,7 @@ class UpdateStatusTravelOrderUseCase
         $this->ruleSomeUserCannotChangeOwnRequest($order, $currentUserId);
         $this->ruleOnlyPendingOrdersCanBeUpdated($order);
 
-        $order->setStatus($status);
+        $order->setStatus(TravelOrderStatus::CANCELLED);
         return $this->repository->update($order);
-    }
-
-    private function ruleSomeUserCannotChangeOwnRequest(TravelOrder $order, ?int $currentUserId): void
-    {
-        if ($order->userId === $currentUserId) {
-            throw new Exception("O usuário que fez o pedido não pode alterar o status.");
-        }
-    }
-
-    private function ruleOnlyPendingOrdersCanBeUpdated(TravelOrder $order): void
-    {
-        if ($order->status !== TravelOrderStatus::PENDING) {
-            throw new Exception("Apenas pedidos com status 'pendente' podem ser atualizados.");
-        }
     }
 }

--- a/app/Application/UseCases/Traits/RulesTravelOrderStatus.php
+++ b/app/Application/UseCases/Traits/RulesTravelOrderStatus.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Application\UseCases\Traits;
+
+trait RulesTravelOrderStatus
+{
+    private function ruleSomeUserCannotChangeOwnRequest($order, $currentUserId): void
+    {
+        if ($order->userId === $currentUserId) {
+            throw new \Exception("O usuário que fez o pedido não pode alterar o status.");
+        }
+    }
+
+    private function ruleOnlyPendingOrdersCanBeUpdated($order): void
+    {
+        if ($order->status !== 'pending') {
+            throw new \Exception("Apenas pedidos com status 'pendente' podem ser atualizados.");
+        }
+    }
+}

--- a/app/Domain/Entities/TravelOrder.php
+++ b/app/Domain/Entities/TravelOrder.php
@@ -35,8 +35,8 @@ class TravelOrder
         $this->id = $id;
     }
 
-    public function setStatus(TravelOrderStatus $status): void
+    public function setStatus(string $status): void
     {
-        $this->status = $status->value;
+        $this->status = $status;
     }
 }

--- a/app/Http/Controllers/TravelOrderController.php
+++ b/app/Http/Controllers/TravelOrderController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Application\UseCases\ApproveTravelOrderUseCase;
+use App\Application\UseCases\CancelTravelOrderUseCase;
 use App\Application\UseCases\GetTravelOrderUseCase;
 use App\Application\UseCases\ListTravelOrderUseCase;
 use App\Application\UseCases\SaveTravelOrderUseCase;
@@ -31,28 +33,28 @@ class TravelOrderController extends Controller
         return response()->json($order, 201);
     }
 
-    public function updateStatus(int $id, string $status)
-    {
-        $validator = validator(
-            ['status' => $status],
-            ['status' => ['in:approved,cancelled']]
-        );
-        
-        if ($validator->fails()) {
-            throw new ValidationException($validator);
-        }
-
+    public function approve(int $id)
+    {   
         try {
-            $order = app(UpdateStatusTravelOrderUseCase::class)->execute(
-                $id,
-                TravelOrderStatus::from($status)
-            );
+            $order = app(ApproveTravelOrderUseCase::class)->execute($id);
         } catch (\Exception $e) {
             return response()->json(['error' => $e->getMessage()], 400);
         }
 
         return response()->json($order, 200);
     }
+
+    public function cancel(int $id)
+    {   
+        try {
+            $order = app(CancelTravelOrderUseCase::class)->execute($id);
+        } catch (\Exception $e) {
+            return response()->json(['error' => $e->getMessage()], 400);
+        }
+
+        return response()->json($order, 200);
+    }
+    
 
     public function show(int $id)
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,5 +18,6 @@ Route::middleware('auth:api')->group(function () {
     Route::get('/travel-order/list', [TravelOrderController::class, 'index']);
     Route::post('/travel-order', [TravelOrderController::class, 'store']);
     Route::get('/travel-order/{id}', [TravelOrderController::class, 'show']);
-    Route::put('/travel-order/{id}/status/{status}', [TravelOrderController::class, 'updateStatus']);
+    Route::put('/travel-order/{id}/approve', [TravelOrderController::class, 'approve']);
+    Route::put('/travel-order/{id}/cancel', [TravelOrderController::class, 'cancel']);
 });


### PR DESCRIPTION
This pull request refactors how travel order status changes are handled, splitting the previous generic status update functionality into dedicated approval and cancellation use cases. It also introduces reusable business rule validation via a trait and updates controller logic and routes to reflect these changes.

**Use case refactoring:**
* Renamed `UpdateStatusTravelOrderUseCase` to `ApproveTravelOrderUseCase`, which now only approves travel orders and applies approval-specific logic. [[1]](diffhunk://#diff-5167ef01e021af15300fcb047184c06c084afc2c9d8ef5bddf889fbadfa891fdR10-R23) [[2]](diffhunk://#diff-5167ef01e021af15300fcb047184c06c084afc2c9d8ef5bddf889fbadfa891fdL34-L50)
* Added new `CancelTravelOrderUseCase` for handling travel order cancellations, with its own execution logic.

**Business rule validation:**
* Introduced `RulesTravelOrderStatus` trait to encapsulate business rules for status changes, now reused by both approval and cancellation use cases.

**Domain model update:**
* Changed the `setStatus` method in `TravelOrder` to accept a string instead of an enum, aligning with the refactored use cases.

**Controller and routes update:**
* Updated `TravelOrderController` to provide separate `approve` and `cancel` endpoints, removing the generic status update method and related validation. [[1]](diffhunk://#diff-05752e42d7ed25f7f17de88c561f81a23d6960544636e677b86ea80782f271b0R5-R6) [[2]](diffhunk://#diff-05752e42d7ed25f7f17de88c561f81a23d6960544636e677b86ea80782f271b0L34-R58)
* Modified API routes to match the new controller methods, removing the old status endpoint.