### PR TITLE
Notifications

### DIFF
--- a/app/Application/UseCases/CancelTravelOrderUseCase.php
+++ b/app/Application/UseCases/CancelTravelOrderUseCase.php
@@ -8,6 +8,7 @@ use App\Domain\Repositories\TravelOrderRepositoryInterface;
 use Exception;
 use Tymon\JWTAuth\Facades\JWTAuth;
 use App\Application\UseCases\Traits\RulesTravelOrderStatus;
+use App\Events\TravelOrderStatusChange;
 
 class CancelTravelOrderUseCase
 {
@@ -15,8 +16,9 @@ class CancelTravelOrderUseCase
 
     private $repository;
 
-    public function __construct(TravelOrderRepositoryInterface $repository)
-    {
+    public function __construct(
+        TravelOrderRepositoryInterface $repository
+    ) {
         $this->repository = $repository;
     }
 
@@ -35,6 +37,9 @@ class CancelTravelOrderUseCase
         $this->ruleOnlyPendingOrdersCanBeUpdated($order);
 
         $order->setStatus(TravelOrderStatus::CANCELLED);
-        return $this->repository->update($order);
+        $order = $this->repository->update($order);
+        TravelOrderStatusChange::dispatch($order);
+
+        return $order;
     }
 }

--- a/app/Domain/Entities/TravelOrder.php
+++ b/app/Domain/Entities/TravelOrder.php
@@ -39,4 +39,9 @@ class TravelOrder
     {
         $this->status = $status;
     }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
 }

--- a/app/Events/TravelOrderStatusChange.php
+++ b/app/Events/TravelOrderStatusChange.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use App\Domain\Entities\TravelOrder;
+
+class TravelOrderStatusChange
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public TravelOrder $travelOrder;
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        TravelOrder $travelOrder
+    )
+    {
+        $this->travelOrder = $travelOrder;
+    }
+}

--- a/app/Listeners/SendNoticationTravelOrder.php
+++ b/app/Listeners/SendNoticationTravelOrder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Domain\Entities\TravelOrder;
+use App\Domain\Enums\TravelOrderStatus;
+use App\Events\TravelOrderStatusChange;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class SendNoticationTravelOrder //implements ShouldQueue
+{
+    //use Queueable;
+    /**
+     * Handle the event.
+     */
+    public function handle(TravelOrderStatusChange $event): void
+    {
+        $travelOrder = $event->travelOrder;
+        $this->sendNotification($travelOrder);
+    }
+
+    private function sendNotification(TravelOrder $travelOrder): void
+    {
+        $message = $this->getMessageByStatus($travelOrder->getStatus());
+
+        // Lógica para enviar a notificação (exemplo: email, SMS, etc.)
+
+        Log::info("Notificação enviada para o usuário {$travelOrder->userId}: $message");
+    }
+
+    private function getMessageByStatus(string $status): string
+    {
+        return match ($status) {
+            TravelOrderStatus::APPROVED => "Seu pedido foi aprovado.",
+            TravelOrderStatus::CANCELLED => "Seu pedido foi cancelado.",
+            default => throw new \InvalidArgumentException("Status de notificação inválido."),
+        };
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,8 +19,6 @@ class AppServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(TravelOrderRepositoryInterface::class, TravelOrderRepository::class);
-        
-
     }
 
     /**


### PR DESCRIPTION
This pull request introduces an event-driven notification system for travel order status changes, improving how status updates are handled and communicated. The main changes include the creation of a new event and listener for travel order status updates, modifications to use cases to dispatch the event, and the addition of a getter for travel order status.

**Event System for Travel Order Status Changes:**

* Added new event `TravelOrderStatusChange` to encapsulate travel order status updates. (`app/Events/TravelOrderStatusChange.php`)
* Created listener `SendNoticationTravelOrder` to handle the event and send notifications based on the updated status. (`app/Listeners/SendNoticationTravelOrder.php`)

**Use Case Modifications:**

* Updated `ApproveTravelOrderUseCase` and `CancelTravelOrderUseCase` to dispatch the `TravelOrderStatusChange` event after updating the travel order status. (`app/Application/UseCases/ApproveTravelOrderUseCase.php`, `app/Application/UseCases/CancelTravelOrderUseCase.php`) [[1]](diffhunk://#diff-5167ef01e021af15300fcb047184c06c084afc2c9d8ef5bddf889fbadfa891fdR5-R23) [[2]](diffhunk://#diff-5167ef01e021af15300fcb047184c06c084afc2c9d8ef5bddf889fbadfa891fdL38-R45) [[3]](diffhunk://#diff-54ae021a693193b00c0e4762c5fdca00d13770155f217906c95c514181c388d8R11-R21) [[4]](diffhunk://#diff-54ae021a693193b00c0e4762c5fdca00d13770155f217906c95c514181c388d8L38-R43)

**Domain Entity Enhancement:**

* Added a `getStatus` method to the `TravelOrder` entity for easier status retrieval in event handling and notifications. (`app/Domain/Entities/TravelOrder.php`)