### PR TITLE
User can manager your orders

### DIFF
--- a/app/Models/Traits/UserOwner.php
+++ b/app/Models/Traits/UserOwner.php
@@ -9,9 +9,9 @@ trait UserOwner
 {
     protected static function bootUserOwner()
     {
-        // static::addGlobalScope(
-        //     new UserOwnerScope(app(UserOwnerManager::class))
-        // );
+        static::addGlobalScope(
+            new UserOwnerScope(app(UserOwnerManager::class))
+        );
 
         static::creating(function ($model) {
             $userOwnerManager = app(UserOwnerManager::class);


### PR DESCRIPTION
This pull request re-enables the global scope for user ownership in the `UserOwner` trait, ensuring that queries on models using this trait are properly filtered by user ownership.

User ownership enforcement:

* [`app/Models/Traits/UserOwner.php`](diffhunk://#diff-a05966e3a603bd6abdbc879f519534c3a157ebf738febf162578ecc55a368fffL12-R14): Re-enabled the `UserOwnerScope` global scope by uncommenting the relevant line in the `bootUserOwner` method, so all queries on models using this trait are automatically scoped to the current user.