### PR TITLE
Units tests

### DIFF
--- a/app/Application/UseCases/SaveTravelOrderUseCase.php
+++ b/app/Application/UseCases/SaveTravelOrderUseCase.php
@@ -3,7 +3,6 @@
 namespace App\Application\UseCases;
 
 use App\Domain\Entities\TravelOrder;
-use App\Domain\Enums\TravelOrderStatus;
 use App\Domain\Repositories\TravelOrderRepositoryInterface;
 
 class SaveTravelOrderUseCase
@@ -15,16 +14,8 @@ class SaveTravelOrderUseCase
         $this->repository = $repository;
     }
 
-    public function execute($data): TravelOrder
+    public function execute(TravelOrder $order): TravelOrder
     {
-        $order = new TravelOrder(
-            requesterName: $data['requester_name'],
-            destination: $data['destination'],
-            departureDate: new \DateTime($data['departure_date']),
-            returnDate: new \DateTime($data['return_date']),
-            status: TravelOrderStatus::PENDING
-        );
-
         return $this->repository->create($order);
     }
 }

--- a/app/Application/UseCases/Traits/RulesTravelOrderStatus.php
+++ b/app/Application/UseCases/Traits/RulesTravelOrderStatus.php
@@ -8,16 +8,16 @@ trait RulesTravelOrderStatus
 {
     const STATUS_PENDING = 'pending';
 
-    private function ruleSomeUserCannotChangeOwnRequest($order, $currentUserId): void
+    private function ruleSomeUserCannotChangeOwnRequest(int $orderUserId, int $currentUserId): void
     {
-        if ($order->userId === $currentUserId) {
+        if ($orderUserId === $currentUserId) {
             throw TravelOrderExceptions::userCannotChangeOwnRequest();
         }
     }
 
-    private function ruleOnlyPendingOrdersCanBeUpdated($order): void
+    private function ruleOnlyPendingOrdersCanBeUpdated(string $status): void
     {
-        if ($order->status !== self::STATUS_PENDING) {
+        if ($status !== self::STATUS_PENDING) {
             throw TravelOrderExceptions::onlyPendingOrdersCanBeUpdated();
         }
     }

--- a/app/Domain/Entities/TravelOrder.php
+++ b/app/Domain/Entities/TravelOrder.php
@@ -43,4 +43,9 @@ class TravelOrder
     {
         return $this->status;
     }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
 }

--- a/app/Listeners/SendNoticationTravelOrder.php
+++ b/app/Listeners/SendNoticationTravelOrder.php
@@ -27,7 +27,7 @@ class SendNoticationTravelOrder //implements ShouldQueue
 
         // Lógica para enviar a notificação (exemplo: email, SMS, etc.)
 
-        Log::info("Notificação enviada para o usuário {$travelOrder->userId}: $message");
+        Log::info("Notificação enviada para o usuário {$travelOrder->user->name}: $message");
     }
 
     private function getMessageByStatus(string $status): string

--- a/tests/Unit/Application/UseCases/ApproveTravelOrderUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/ApproveTravelOrderUseCaseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Unit\Application\UseCases;
+use Tests\TestCase;
+use App\Application\UseCases\ApproveTravelOrderUseCase;
+use App\Domain\Entities\TravelOrder;
+use App\Domain\Entities\User;
+use App\Domain\Enums\TravelOrderStatus;
+use App\Domain\Repositories\TravelOrderRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Illuminate\Support\Facades\Event;
+use App\Events\TravelOrderStatusChange;
+
+class ApproveTravelOrderUseCaseTest extends TestCase
+{
+    private ApproveTravelOrderUseCase $unit;
+    private MockObject $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = $this->createMock(TravelOrderRepositoryInterface::class);
+        $this->unit = app(ApproveTravelOrderUseCase::class, [
+            'repository' => $this->repository,
+        ]);
+    }
+
+    public function testApproveTravelOrderSuccess(): void
+    {
+        Event::fake();
+
+        $returnRepository = new TravelOrder(
+            id: 1,
+            requesterName: 'John Doe',
+            destination: 'Paris',
+            departureDate: new \DateTime('2023-10-01'),
+            returnDate: new \DateTime('2023-10-10'),
+            status: TravelOrderStatus::PENDING,
+            user: new User(
+                id: 2,
+                name: 'Any User',
+                email: 'any@example.com'
+            )
+        );
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findById')
+            ->with($this->equalTo(1))
+            ->willReturn($returnRepository);
+
+        $orderChanged = clone $returnRepository;
+        $orderChanged->setStatus(TravelOrderStatus::APPROVED);
+
+        $this->repository
+            ->expects($this->once())
+            ->method('update')
+            ->with($this->equalTo($orderChanged))
+            ->willReturn($orderChanged);
+
+        $result = $this->unit->execute(1, 1);
+
+        $this->assertInstanceOf(TravelOrder::class, $result);
+        $this->assertEquals(TravelOrderStatus::APPROVED, $result->getStatus());
+
+        Event::assertDispatched(TravelOrderStatusChange::class, function ($event) use ($orderChanged) {
+            return $event->travelOrder->getId() === $orderChanged->getId()
+                && $event->travelOrder->getStatus() === $orderChanged->getStatus();
+        });
+    }
+
+    public function testApproveTravelOrderNotFound(): void
+    {
+        $this->repository
+            ->expects($this->once())
+            ->method('findById')
+            ->with($this->equalTo(999))
+            ->willReturn(null);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Pedido não encontrado.");
+
+        $this->unit->execute(999, 1);
+    }
+    
+    public function testApproveTravelOrderUserCannotChangeOwnRequest(): void
+    {
+        $returnRepository = new TravelOrder(
+            id: 1,
+            requesterName: 'John Doe',
+            destination: 'Paris',
+            departureDate: new \DateTime('2023-10-01'),
+            returnDate: new \DateTime('2023-10-10'),
+            status: TravelOrderStatus::PENDING,
+            user: new User(
+                id: 1,
+                name: 'John Doe',
+                email: 'john@example.com'
+            )
+        );
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findById')
+            ->with($this->equalTo(1))
+            ->willReturn($returnRepository);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Um usuário não pode aprovar ou cancelar seu próprio pedido.");
+
+        $this->unit->execute(1, 1);
+    }
+}

--- a/tests/Unit/Application/UseCases/CancelTravelOrderUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/CancelTravelOrderUseCaseTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Unit\Application\UseCases;
+
+use Tests\TestCase;
+use App\Domain\Entities\TravelOrder;
+use App\Domain\Entities\User;
+use App\Domain\Enums\TravelOrderStatus;
+use App\Domain\Repositories\TravelOrderRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Illuminate\Support\Facades\Event;
+use App\Events\TravelOrderStatusChange;
+use App\Application\UseCases\CancelTravelOrderUseCase;
+
+class CancelTravelOrderUseCaseTest extends TestCase
+{
+    private CancelTravelOrderUseCase $unit;
+    private MockObject $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = $this->createMock(TravelOrderRepositoryInterface::class);
+        $this->unit = app(CancelTravelOrderUseCase::class, [
+            'repository' => $this->repository,
+        ]);
+    }
+
+    public function testCancelTravelOrderSuccess(): void
+    {
+        Event::fake();
+
+        $returnRepository = new TravelOrder(
+            id: 1,
+            requesterName: 'John Doe',
+            destination: 'Paris',
+            departureDate: new \DateTime('2023-10-01'),
+            returnDate: new \DateTime('2023-10-10'),
+            status: TravelOrderStatus::PENDING,
+            user: new User(
+                id: 2,
+                name: 'Any User',
+                email: 'any@example.com'
+            )
+        );
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findById')
+            ->with($this->equalTo(1))
+            ->willReturn($returnRepository);
+
+        $orderChanged = clone $returnRepository;
+        $orderChanged->setStatus(TravelOrderStatus::CANCELLED);
+
+        $this->repository
+            ->expects($this->once())
+            ->method('update')
+            ->with($this->equalTo($orderChanged))
+            ->willReturn($orderChanged);
+
+        $result = $this->unit->execute(1, 1);
+
+        $this->assertInstanceOf(TravelOrder::class, $result);
+        $this->assertEquals(TravelOrderStatus::CANCELLED, $result->getStatus());
+
+        Event::assertDispatched(TravelOrderStatusChange::class, function ($event) use ($orderChanged) {
+            return $event->travelOrder->getId() === $orderChanged->getId()
+                && $event->travelOrder->getStatus() === $orderChanged->getStatus();
+        });
+    }
+
+    public function testApproveTravelOrderNotFound(): void
+    {
+        $this->repository
+            ->expects($this->once())
+            ->method('findById')
+            ->with($this->equalTo(999))
+            ->willReturn(null);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Pedido não encontrado.");
+
+        $this->unit->execute(999, 1);
+    }
+    
+    public function testApproveTravelOrderUserCannotChangeOwnRequest(): void
+    {
+        $returnRepository = new TravelOrder(
+            id: 1,
+            requesterName: 'John Doe',
+            destination: 'Paris',
+            departureDate: new \DateTime('2023-10-01'),
+            returnDate: new \DateTime('2023-10-10'),
+            status: TravelOrderStatus::PENDING,
+            user: new User(
+                id: 1,
+                name: 'John Doe',
+                email: 'john@example.com'
+            )
+        );
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findById')
+            ->with($this->equalTo(1))
+            ->willReturn($returnRepository);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Um usuário não pode aprovar ou cancelar seu próprio pedido.");
+
+        $this->unit->execute(1, 1);
+    }
+}

--- a/tests/Unit/Application/UseCases/SaveTravelOrderUseCaseTest.php
+++ b/tests/Unit/Application/UseCases/SaveTravelOrderUseCaseTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit\Application\UseCases;
+
+use App\Application\UseCases\SaveTravelOrderUseCase;
+use App\Domain\Entities\TravelOrder;
+use App\Domain\Enums\TravelOrderStatus;
+use App\Domain\Repositories\TravelOrderRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Tests\TestCase;
+
+class SaveTravelOrderUseCaseTest extends TestCase
+{
+    private SaveTravelOrderUseCase $unit;
+    private MockObject $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = $this->createMock(TravelOrderRepositoryInterface::class);
+        $this->unit = app(SaveTravelOrderUseCase::class, [
+            'repository' => $this->repository,
+        ]);
+    }
+
+    public function testSaveTravelOrder(): void
+    {
+        $order = new TravelOrder(
+            requesterName: 'John Doe',
+            destination: 'Paris',
+            departureDate: new \DateTime('2023-10-01'),
+            returnDate: new \DateTime('2023-10-10'),
+            status: TravelOrderStatus::PENDING
+        );
+
+        $this->repository
+            ->expects($this->once())
+            ->method('create')
+            ->with($this->equalTo($order))
+            ->willReturn($order);
+        $result = $this->unit->execute($order);
+
+        $this->assertInstanceOf(TravelOrder::class, $result);
+    }
+}


### PR DESCRIPTION
This pull request refactors the travel order use cases and controller to improve separation of concerns and testability. The main changes include removing direct JWT authentication from use case classes, updating method signatures to accept the current user ID as a parameter, and moving request object construction to the controller. Comprehensive unit tests have also been added for all use cases.

**Use Case Refactoring:**

* The `ApproveTravelOrderUseCase` and `CancelTravelOrderUseCase` now receive the current user ID as a parameter instead of extracting it from JWT inside the use case. This decouples authentication from business logic and improves testability. (`app/Application/UseCases/ApproveTravelOrderUseCase.php`, `app/Application/UseCases/CancelTravelOrderUseCase.php`, [[1]](diffhunk://#diff-5167ef01e021af15300fcb047184c06c084afc2c9d8ef5bddf889fbadfa891fdL28-R33) [[2]](diffhunk://#diff-54ae021a693193b00c0e4762c5fdca00d13770155f217906c95c514181c388d8L26-R33)
* The `SaveTravelOrderUseCase` now expects a fully constructed `TravelOrder` entity as input, moving the responsibility for creating the entity to the controller. (`app/Application/UseCases/SaveTravelOrderUseCase.php`, [app/Application/UseCases/SaveTravelOrderUseCase.phpL18-L27](diffhunk://#diff-bb5a4d98d13ceb96b75ba43187e5cd213ea1780d85ddb9a9d435e6a5f37b0c1eL18-L27))

**Controller Updates:**

* The `TravelOrderController` now handles JWT authentication and constructs the `TravelOrder` entity before passing it to the use case. It also passes the current user ID to the approve and cancel use cases. (`app/Http/Controllers/TravelOrderController.php`, [[1]](diffhunk://#diff-05752e42d7ed25f7f17de88c561f81a23d6960544636e677b86ea80782f271b0L23-R45) [[2]](diffhunk://#diff-05752e42d7ed25f7f17de88c561f81a23d6960544636e677b86ea80782f271b0R55-R59)

**Business Rule Improvements:**

* The `RulesTravelOrderStatus` trait methods now accept primitive types (`int` for user IDs, `string` for status) instead of domain objects, simplifying their usage and improving clarity. (`app/Application/UseCases/Traits/RulesTravelOrderStatus.php`, [app/Application/UseCases/Traits/RulesTravelOrderStatus.phpL11-R20](diffhunk://#diff-b65bf39a340547a2bb7289867c3f58b2b9d2437d0238cbbe867cd098509fddd1L11-R20))

**Testing Enhancements:**

* Added new unit tests for all use cases: approving, cancelling, and saving travel orders, including edge cases like not found and user cannot approve/cancel their own request. (`tests/Unit/Application/UseCases/ApproveTravelOrderUseCaseTest.php`, [[1]](diffhunk://#diff-a35028cbb6778203b1a1041a7e899a252d8a04a57749348fd57e590040966e30R1-R114); `tests/Unit/Application/UseCases/CancelTravelOrderUseCaseTest.php`, [[2]](diffhunk://#diff-753fe9c0a5e01c108a05021403f1241a7445e21a310702c6559a54d78e955316R1-R115); `tests/Unit/Application/UseCases/SaveTravelOrderUseCaseTest.php`, [[3]](diffhunk://#diff-5b6b942bc53c9f02d99e1ef429b6f9a42567396a5b49ebda949fa117dabb9d71R1-R46)

**Minor Improvements:**

* Improved notification logging to use the user's name instead of ID for better readability. (`app/Listeners/SendNoticationTravelOrder.php`, [app/Listeners/SendNoticationTravelOrder.phpL30-R30](diffhunk://#diff-3114058a9ec6a676d291714c26f4c46273dcc987de684e65ca6e3c80634cda7cL30-R30))
* Added a `getId()` method to the `TravelOrder` entity for easier access in tests and events. (`app/Domain/Entities/TravelOrder.php`, [app/Domain/Entities/TravelOrder.phpR46-R50](diffhunk://#diff-50489cae3529b788f6138c6db8e2ad5d15ac0a89cf46bee5b2350e984f59a517R46-R50))